### PR TITLE
Embed Corbado Observe YouTube videos in docs

### DIFF
--- a/corbado-observe/overview/welcome.mdx
+++ b/corbado-observe/overview/welcome.mdx
@@ -4,6 +4,17 @@ description: "Track authentication journeys, identify drop-offs, and improve log
 sidebarTitle: "Welcome"
 ---
 
+<Frame>
+  <iframe
+    className="w-full aspect-video rounded-xl"
+    src="https://www.youtube.com/embed/KSUOj1-B2CY"
+    title="Stop Flying Blind on Passkeys | Corbado Observe Overview"
+    frameBorder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+  />
+</Frame>
+
 ## 1. Introduction
 
 **Corbado Observe** is an observability tool for authentication flows. It captures structured events from your application and maps them to a clear data model so you can understand user behavior, identify drop-offs, and improve login and sign-up conversion.

--- a/corbado-observe/tracking/decisions.mdx
+++ b/corbado-observe/tracking/decisions.mdx
@@ -6,6 +6,17 @@ sidebarTitle: "Decisions"
 
 Decisions capture explicit choice points in an authentication journey.
 
+<Frame>
+  <iframe
+    className="w-full aspect-video rounded-xl"
+    src="https://www.youtube.com/embed/CLogBNykxnQ"
+    title="Passkey vs Password: See what Users actually use | Corbado Observe"
+    frameBorder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+  />
+</Frame>
+
 Use decisions to track:
 
 - **User choices**, for example selecting between passkey login, password login, or social login

--- a/corbado-observe/tracking/flows.mdx
+++ b/corbado-observe/tracking/flows.mdx
@@ -6,6 +6,17 @@ sidebarTitle: "Flows"
 
 Flows represent an end-to-end user journey in **Corbado Observe**, for example login or sign-up.
 
+<Frame>
+  <iframe
+    className="w-full aspect-video rounded-xl"
+    src="https://www.youtube.com/embed/zuFzTwNJuU0"
+    title="Find Passkey Drop-Offs in your Funnel | Corbado Observe"
+    frameBorder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+  />
+</Frame>
+
 Each flow is built from smaller units:
 
 - [**Decisions**](/corbado-observe/tracking/decisions) (for example method selection or route choice)

--- a/corbado-observe/tracking/subflows.mdx
+++ b/corbado-observe/tracking/subflows.mdx
@@ -6,6 +6,17 @@ sidebarTitle: "Subflows"
 
 Subflows are the concrete building blocks inside a [flow](/corbado-observe/tracking/flows) and are **auto-discovered** by **Corbado Observe** based on the events you send. They represent a specific authentication method, for example passkey login, password enrollment, or email OTP verification.
 
+<Frame>
+  <iframe
+    className="w-full aspect-video rounded-xl"
+    src="https://www.youtube.com/embed/ImkgPLTKKcQ"
+    title="Track Passkey Enrollment in Real-Time | Corbado Observe"
+    frameBorder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+  />
+</Frame>
+
 <Info>
   Install and set up the **Corbado Observe SDK**, including your first tracked event, in [Getting started](/corbado-observe/overview/getting-started). This page explains the subflow concept and documents all available subflow types.
 </Info>

--- a/corbado-observe/tracking/user.mdx
+++ b/corbado-observe/tracking/user.mdx
@@ -8,6 +8,17 @@ In **Corbado Observe**, users are a mirror of your own user entities.
 
 **Corbado Observe** does not create an independent user model for authentication logic. Instead, it links events to your users so you can analyze authentication per user across multiple flows.
 
+<Frame>
+  <iframe
+    className="w-full aspect-video rounded-xl"
+    src="https://www.youtube.com/embed/1mQBtnjtNLw"
+    title="Debug any Passkey User in Seconds | Corbado Observe"
+    frameBorder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+  />
+</Frame>
+
 ## 1. Why user mapping matters
 
 Adding user information to events helps you:


### PR DESCRIPTION
Add the new Observe walkthrough videos to the matching docs pages:
- welcome: Observe overview ("Stop Flying Blind")
- tracking/subflows: enrollment tracking
- tracking/flows: funnel drop-off analysis
- tracking/user: user debug search
- tracking/decisions: passkey vs password