### PR TITLE
Update funnel analysis video link in Observe docs

### DIFF
--- a/corbado-observe/tracking/flows.mdx
+++ b/corbado-observe/tracking/flows.mdx
@@ -9,7 +9,7 @@ Flows represent an end-to-end user journey in **Corbado Observe**, for example l
 <Frame>
   <iframe
     className="w-full aspect-video rounded-xl"
-    src="https://www.youtube.com/embed/zuFzTwNJuU0"
+    src="https://www.youtube.com/embed/n_ztfoPszsM"
     title="Find Passkey Drop-Offs in your Funnel | Corbado Observe"
     frameBorder="0"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"


### PR DESCRIPTION
Replace the old re-recorded "Find Passkey Drop-Offs in your Funnel" video (zuFzTwNJuU0) with the new version (n_ztfoPszsM) on the Flows page.