### PR TITLE
Restructure passkey UI flow docs for first-time readers

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -228,6 +228,7 @@
                         "group": "Overview",
                         "pages": [
                             "passkey-ui-flows/overview",
+                            "passkey-ui-flows/flow-catalogue",
                             "passkey-ui-flows/benchmarking",
                             "passkey-ui-flows/passkey-intelligence"
                         ]

--- a/passkey-ui-flows/benchmarking.mdx
+++ b/passkey-ui-flows/benchmarking.mdx
@@ -1,36 +1,39 @@
 ---
 title: "Benchmarking Passkey Implementations"
-description: "Acceptance criteria and a practical framework for comparing passkey implementations, provider coverage and adoption potential."
+sidebarTitle: "3. Benchmarking"
+description: "A five-step method for grading a passkey implementation against product-neutral acceptance criteria and rating its adoption potential."
 ---
 
-This benchmark tries to turn the [flow catalogue](/passkey-ui-flows/overview#flow-catalogue) into product-neutral requirements. Each flow includes acceptance criteria that can be used for implementation reviews, tickets and provider comparisons.
+import { BenchmarkRatingLadder, AdoptionPillars } from "/snippets/passkey-ui-flows/rating-ladder.mdx";
+import LegendBenchmarkAs from "/snippets/passkey-ui-flows/legend-benchmark-as.mdx";
+import LegendUserReach from "/snippets/passkey-ui-flows/legend-user-reach.mdx";
+import LegendAvailability from "/snippets/passkey-ui-flows/legend-availability.mdx";
 
-## Decide what you are reviewing
+This method turns the [flow catalogue](/passkey-ui-flows/flow-catalogue) into product-neutral requirements you can use for implementation reviews, tickets and provider comparisons.
 
-Before giving an implementation a rating, state what you reviewed. Include the website or app, user and account groups, browsers, operating systems, credential managers, countries and time period. Also list anything that was excluded or not tested.
+You declare a scope first, then ratings roll up through four stages. Every table on this page belongs to one of these five steps:
+
+<BenchmarkRatingLadder />
+
+## Step 1. Define your scope
+
+Before giving an implementation a rating, state what you reviewed:
+
+- The website or app
+- User and account groups
+- Browsers, operating systems and credential managers
+- Countries and time period
+- **Anything excluded or not tested**
 
 When comparing providers, review them under the same conditions. If a provider does not support a relevant platform or flow, show this as a gap. Use `N/A` only when a requirement does not apply to the reviewed implementation.
 
-Also state whether each capability is built in, can be configured, requires integration work or requires custom development. This separates the quality of the result from the effort needed to achieve it.
+Also state whether each capability is **built in**, **configurable**, **requires integration work** or **requires custom development**. This separates the quality of the result from the effort needed to achieve it.
 
-## How to read the flow metadata
+## Step 2. Grade each criterion
 
-| Field | Value | Meaning |
-| --- | --- | --- |
-| Benchmark as | **Baseline** | Expected production behavior whenever passkeys are in scope. |
-| Benchmark as | **Strategy** | One primary UX pattern that can coexist with or substitute for another strategy. Do not require every alternative. |
-| Benchmark as | **Conditional** | Required only when its documented scenario occurs in the declared scope. |
-| Benchmark as | **Enhancement** | Progressive capability that improves the flow where supported; unsupported targets are not penalized. |
-| Benchmark as | **Supporting capability** | Non-UI behavior that improves several flows. |
-| Expected adoption impact | **High** | Directly affects a frequent, broad creation or returning-login opportunity. |
-| Expected adoption impact | **Mid** | Expands device coverage, recovery or another important part of the user base. |
-| Expected adoption impact | **Low** | Primarily improves lifecycle hygiene, trust or administration rather than direct funnel exposure. |
+Every flow page ends with its acceptance criteria, each carrying an ID such as `W1.1-AC03`. Grade them one by one.
 
-Expected adoption impact is a qualitative estimate for the full audience. It is not a measure of overall importance and does not affect whether a criterion passes. For example, credential management and Signal API reconciliation have low expected adoption impact but high reliability and lifecycle value.
-
-## Grade the criteria and flows
-
-Test important platforms separately. A feature that works on Chrome but fails on Safari should show one pass and one fail rather than one combined result.
+Test important platforms separately. A feature that works on Chrome but fails on Safari is one pass and one fail, not one combined result.
 
 | Result | Use when |
 | --- | --- |
@@ -39,7 +42,42 @@ Test important platforms separately. A feature that works on Chrome but fails on
 | **N/A** | The criterion does not apply. State why. |
 | **Not reviewed** | There is not enough evidence to give a result. |
 
-Core criteria cover behavior that must work, including security, account binding, completion, cancellation and fallback. Quality criteria cover measurement, testing and maintainability.
+Criteria come in two levels. **Core** covers behavior that must work: security, account binding, completion, cancellation and fallback. **Quality** covers measurement, testing and maintainability.
+
+Use a simple review table:
+
+| Criterion | Platform | Result | Evidence | Notes |
+| --- | --- | --- | --- | --- |
+| `W1.2-AC01` | Safari 18 with Apple Passwords | Pass / Fail / N/A / Not reviewed | Test, documentation or analytics link | Result or reason |
+
+Also record how strong the evidence is:
+
+| Confidence | Evidence |
+| --- | --- |
+| **High** | Current tests across the supported platforms, preferably with production data |
+| **Medium** | Direct tests exist, but some platforms or user groups are missing |
+| **Low** | Documentation, a demo, screenshot or narrow happy-path test |
+| **Unknown** | No evidence is available |
+
+Two pieces of flow metadata decide how a criterion is judged. **Benchmark as** sets how strictly the flow is required, and **User reach** describes how much of the user base it touches. Both are listed for every flow in the [availability matrix](/passkey-ui-flows/flow-catalogue#availability-matrix).
+
+### Benchmark as
+
+<LegendBenchmarkAs />
+
+### User reach
+
+<LegendUserReach />
+
+### Availability
+
+<LegendAvailability />
+
+## Step 3. Roll up to a flow rating
+
+Step 2 grades one criterion at a time. A flow has around ten of them, so step 3 turns those results into a single verdict per reviewed platform. That verdict, not the individual criteria, is what the pillars in step 4 consume.
+
+The roll-up is not simply "all passed". It separates **Core** from **Quality**: a flow whose Core criteria all pass but which fails one Quality criterion is **Core met**, which is a usable, secure flow with a measurement or maintainability gap. That is a different finding from **Not met**, where something a user depends on is broken.
 
 | Flow rating | Meaning |
 | --- | --- |
@@ -49,24 +87,11 @@ Core criteria cover behavior that must work, including security, account binding
 | **Not reviewed** | One or more Core criteria were not reviewed and no Core criterion is known to fail. |
 | **N/A** | The complete flow does not apply to the reviewed implementation. |
 
-Use a simple review table:
-
-| Criterion | Platform | Result | Evidence | Notes |
-| --- | --- | --- | --- | --- |
-| `W1.2-AC01` | Safari 18 with Apple Passwords | Pass / Fail / N/A / Not reviewed | Test, documentation or analytics link | Result or reason |
-
-Also state how strong the available evidence is:
-
-| Confidence | Evidence |
-| --- | --- |
-| **High** | Current tests across the supported platforms, preferably with production data |
-| **Medium** | Direct tests exist, but some platforms or user groups are missing |
-| **Low** | Documentation, a demo, screenshot or narrow happy-path test |
-| **Unknown** | No evidence is available |
-
-## Rate adoption potential
+## Step 4. Score the four pillars
 
 Do not rate adoption by counting passed criteria. A login strategy, an optional enhancement and a management feature have different purposes. Instead, review four separate areas:
+
+<AdoptionPillars />
 
 | Pillar | Question |
 | --- | --- |
@@ -75,7 +100,7 @@ Do not rate adoption by counting passed criteria. A login strategy, an optional 
 | **Availability** | Can an enrolled credential be reached in the returning context, including cross-device and second-device cases? |
 | **Usage** | When a usable passkey is available, does the entry design lead users to initiate and complete passkey login? |
 
-The following table shows which flows contribute to each area. A primary flow provides the main result. A secondary flow improves or protects that result but cannot satisfy the area by itself.
+A **primary** flow provides the main result for a pillar. A **secondary** flow improves or protects that result but cannot satisfy the pillar by itself.
 
 | Pillar | Primary flow IDs | Secondary flow IDs |
 | --- | --- | --- |
@@ -84,7 +109,7 @@ The following table shows which flows contribute to each area. A primary flow pr
 | **Availability** | `W1.4`, `W2.4`–`W2.6`, `N2.3` | `W1.5`, `W3.1`, `W3.2`, `N1.4`, `N3.1`, `N3.2`, `E1` |
 | **Usage** | `W1.1`, `W1.3`, `N1.1`, `N1.3` | `W1.2`, `W1.4`–`W1.6`, `N1.2`, `N1.4`, `E1` |
 
-Rate each included website or app separately. If an implementation uses a different flow to achieve the same result, assess it against the same acceptance criteria.
+Give each pillar the highest level it **fully** meets:
 
 | Pillar | Basic | Managed | Optimized |
 | --- | --- | --- | --- |
@@ -93,25 +118,31 @@ Rate each included website or app separately. If an implementation uses a differ
 | **Availability** | Returning login, fallback and passkey management work. | Relevant cross-device, second-device and recovery flows work. | Credential-manager reconciliation works where supported. |
 | **Usage** | At least one primary passkey-login strategy and its error handling work. | The selected primary strategy is Full and its usage can be measured. | Readiness and relevant discovery enhancements also work. |
 
-If an area does not reach Basic or was not reviewed, the overall result is **Incomplete**. Otherwise, give each area the highest level it fully meets.
+Rate each included website or app separately. If an implementation uses a different flow to achieve the same result, assess it against the same acceptance criteria. If a pillar does not reach Basic or was not reviewed, the overall result is **Incomplete**.
 
-Then determine adoption potential without averaging the pillars:
+## Step 5. Determine adoption potential
+
+This is the final result of the review. It rates the whole implementation, where **User reach** in the catalogue rates a single flow.
+
+Do not average the pillars. Apply these rules:
 
 | Adoption potential | Rule |
 | --- | --- |
-| **Incomplete** | At least one area is below Basic or was not reviewed. |
+| **Incomplete** | At least one pillar is below Basic or was not reviewed. |
 | **Low** | Enrollment or Usage remains Basic, so passkey creation or repeat-login discovery is limited. |
 | **Mid** | Enrollment and Usage are at least Managed, and Readiness and Availability are at least Basic. |
 | **High** | Enrollment and Usage are Optimized, and Readiness and Availability are at least Managed. |
 
-Determine adoption potential for web and native separately, then use the lowest result across the included applications, ordered Incomplete < Low < Mid < High. An application that was not reviewed counts as Incomplete. Always show the individual results and state what was not included. For example: **Incomplete overall; web: High; native: Incomplete (not reviewed)**.
+Determine adoption potential for web and native separately, then take the lowest result across the included applications, ordered `Incomplete < Low < Mid < High`. An application that was not reviewed counts as Incomplete. Always show the individual results and state what was not included.
 
-This rates adoption **potential**, not actual adoption. A live deployment should also report enrollment, passkey login share, success, fallback and error rates for a stated user group and time period.
+<Note>
+    This rates adoption **potential**, not actual adoption. A live deployment should also report enrollment, passkey login share, success, fallback and error rates for a stated user group and time period.
 
-For automatic creation, calculate the upgrade rate as successful server registrations divided by conditional-registration requests sent after a completed password sign-in. Do not estimate whether the credential provider considered a request eligible.
+    For automatic creation, calculate the upgrade rate as successful server registrations divided by conditional-registration requests sent after a completed password sign-in. Do not estimate whether the credential provider considered a request eligible.
+</Note>
 
 ## Using evidence
 
-Use specifications and official platform documentation for protocol and API behavior. Use cross-platform UX research and named deployments for flow guidance. Corbado blog and internal implementation experience help explain feasibility, edge cases and estimated adoption impact, but proprietary performance figures are not universal pass/fail thresholds.
+Use specifications and official platform documentation for protocol and API behavior. Use cross-platform UX research and named deployments for flow guidance. Corbado blog posts and internal implementation experience help explain feasibility, edge cases and estimated user reach, but proprietary performance figures are not universal pass/fail thresholds.
 
 Each criterion includes a practical check and references that explain why it is included. During a review, add the test result, documentation or analytics used for the rating.

--- a/passkey-ui-flows/flow-catalogue.mdx
+++ b/passkey-ui-flows/flow-catalogue.mdx
@@ -1,0 +1,156 @@
+---
+title: "Passkey UI Flow Catalogue"
+sidebarTitle: "2. Flow catalogue"
+description: "All 28 passkey UI flows for web and native apps, grouped by login, creation and management, with availability, user reach and acceptance criteria."
+---
+
+import { PasskeyLifecycleMap } from "/snippets/passkey-ui-flows/lifecycle-map.mdx";
+import MetadataLegend from "/snippets/passkey-ui-flows/metadata-legend.mdx";
+
+All 28 flows, grouped by the three phases of the passkey lifecycle. This is a reference, not something you are meant to read top to bottom. Use the [Benchmark as](#benchmark-as-how-strictly-a-flow-is-judged) class to see which flows are expected of every implementation and which apply only in their documented scenario.
+
+<PasskeyLifecycleMap />
+
+**User reach** estimates how much of the user base a flow touches. It is an estimate for planning, never a score to add up. Each flow's platform requirements and benchmark class are in the [availability matrix](#availability-matrix) at the bottom of this page.
+
+<MetadataLegend />
+
+## How the flows are numbered
+
+Every flow carries a stable ID. Use it when scoping an implementation, comparing platforms or filing tickets.
+
+| Part | Values | Example |
+| --- | --- | --- |
+| Platform | `W` web, `N` native, `E` platform-independent | **W**2.3 |
+| Phase | `1` login, `2` creation, `3` management | W**2**.3 |
+| Flow | Appended in order, so existing IDs never shift | W2.**3** |
+
+Individual acceptance criteria extend the ID, for example `W1.1-AC03`. The phase digit follows the ID scheme, not the order you build in: creation is `2` but comes first in the lifecycle.
+
+## 1. Passkey login
+
+Getting a returning user in with a passkey they already have.
+
+### Login on the web
+
+| ID | Flow | When it applies | Reach |
+| --- | --- | --- | --- |
+| **W1.1** | [One-Tap](/passkey-ui-flows/web/passkey-login/one-tap) | A returning user should see a single, explicit passkey button | High |
+| **W1.2** | [Conditional UI](/passkey-ui-flows/web/passkey-login/conditional-ui) | You want usernameless login offered inside the identifier field | High |
+| **W1.3** | [Identifier-first](/passkey-ui-flows/web/passkey-login/identifier-first) | You already run an identifier-first login form | High |
+| **W1.4** | [Cross-device via QR](/passkey-ui-flows/web/passkey-login/cross-device-qr) | The user's passkey lives on their phone | Mid |
+| **W1.5** | [Login error states](/passkey-ui-flows/web/passkey-login/error-states) | You are designing failure handling and fallback | Mid |
+| **W1.6** | [Immediate mode](/passkey-ui-flows/web/passkey-login/immediate-mode) | A client has an immediately available credential and should offer a faster login | Mid |
+
+### Login in native apps
+
+| ID | Flow | When it applies | Reach |
+| --- | --- | --- | --- |
+| **N1.1** | [App-start overlay](/passkey-ui-flows/native/passkey-login/overlay) | The app should offer a passkey before the user types anything | High |
+| **N1.2** | [Conditional UI](/passkey-ui-flows/native/passkey-login/conditional-ui) | You want passkeys suggested from the keyboard | Mid |
+| **N1.3** | [Identifier-first](/passkey-ui-flows/native/passkey-login/identifier-first) | The app collects an identifier before authenticating | High |
+| **N1.4** | [Login error states](/passkey-ui-flows/native/passkey-login/error-states) | You need recoverable, platform-aware failure handling | Mid |
+
+## 2. Passkey creation
+
+Getting a passkey onto the user's device in the first place. This is where adoption is won or lost.
+
+### Creation on the web
+
+| ID | Flow | When it applies | Reach |
+| --- | --- | --- | --- |
+| **W2.1** | [Automatic upgrade (conditional create)](/passkey-ui-flows/web/passkey-creation/automatic-upgrade) | A password was just filled by the user's credential manager | Mid |
+| **W2.2** | [After login, non-MFA (post-login nudge)](/passkey-ui-flows/web/passkey-creation/non-mfa) | A single-factor account should be offered a passkey after login | High |
+| **W2.3** | [After login, MFA (post-login nudge)](/passkey-ui-flows/web/passkey-creation/mfa) | An MFA account should be offered a passkey after verification | High |
+| **W2.4** | [After hybrid login](/passkey-ui-flows/web/passkey-creation/after-hybrid) | The user just signed in by scanning a QR code | Mid |
+| **W2.5** | [After passkey error](/passkey-ui-flows/web/passkey-creation/after-error) | A passkey attempt failed and verified fallback creates another usable credential | Mid |
+| **W2.6** | [On 2nd device](/passkey-ui-flows/web/passkey-creation/on-2nd-device) | The account's passkeys were created before this device was first seen | Mid |
+| **W2.7** | [During sign-up](/passkey-ui-flows/web/sign-up) | A new account should create a passkey during registration | Mid |
+| **W2.8** | [Creation cancellation](/passkey-ui-flows/web/passkey-creation/cancellation) | An explicit creation offer can be skipped or its system ceremony cancelled | Mid |
+
+### Creation in native apps
+
+| ID | Flow | When it applies | Reach |
+| --- | --- | --- | --- |
+| **N2.1** | [After login, non-MFA (post-login nudge)](/passkey-ui-flows/native/passkey-creation/non-mfa) | A single-factor account should be offered a passkey after login | High |
+| **N2.2** | [After login, MFA (post-login nudge)](/passkey-ui-flows/native/passkey-creation/mfa) | An MFA account should be offered a passkey after verification | High |
+| **N2.3** | [After passkey error](/passkey-ui-flows/native/passkey-creation/after-error) | A failed passkey attempt is followed by verified fallback and another usable credential | Mid |
+| **N2.4** | [In-app nudge after unlock](/passkey-ui-flows/native/passkey-creation/in-app-after-unlock) | Long-lived sessions make post-login enrollment rare | Mid |
+| **N2.5** | [In-app nudge on key action](/passkey-ui-flows/native/passkey-creation/in-app-after-cta) | A relevant completed action provides a less disruptive time for enrollment | Mid |
+| **N2.6** | [Automatic upgrade (conditional create)](/passkey-ui-flows/native/passkey-creation/automatic-upgrade) | A password was just filled by the user's credential manager in your app | Mid |
+
+## 3. Passkey management
+
+Letting users and your server keep the set of credentials correct over time.
+
+### Management on the web
+
+| ID | Flow | When it applies | Reach |
+| --- | --- | --- | --- |
+| **W3.1** | [Passkey management](/passkey-ui-flows/web/passkey-management) | Users need to list, add and revoke their own passkeys | Low |
+| **W3.2** | [WebAuthn Signal API](/passkey-ui-flows/web/signal-api) | Keeping the credential manager in sync with what your server accepts | Low |
+
+### Management in native apps
+
+| ID | Flow | When it applies | Reach |
+| --- | --- | --- | --- |
+| **N3.1** | [Passkey management](/passkey-ui-flows/native/passkey-management) | Users need to list, add and revoke their own passkeys | Low |
+| **N3.2** | [WebAuthn Signal API](/passkey-ui-flows/native/signal-api) | Keeping the credential manager in sync with what your server accepts | Low |
+
+## Passkey Intelligence
+
+Not a UI flow. It decides *whether* one of the flows above should run. The benchmark checks the resulting behavior and does not require a proprietary engine.
+
+| ID | Capability | What it decides | Reach |
+| --- | --- | --- | --- |
+| **E1** | [Passkey Intelligence](/passkey-ui-flows/passkey-intelligence) | Whether to attempt, offer, defer or fall back from a passkey flow in the current context | High |
+
+## Availability matrix
+
+<Accordion title="Platform requirements and benchmark class for every flow">
+
+| ID | Availability | Benchmark as | Exact requirements |
+| --- | --- | --- | --- |
+| **W1.1** | Universal | Strategy | All modern browsers |
+| **W1.2** | Universal | Enhancement | All modern browsers |
+| **W1.3** | Universal | Strategy | All modern browsers |
+| **W1.4** | Desktop only | Conditional | Desktop; needs Bluetooth and internet |
+| **W1.5** | Universal | Baseline | All |
+| **W1.6** | Limited | Enhancement | Chrome only; feature-detect `immediateGet` |
+| **W2.1** | Limited | Enhancement | Chrome 136+ desktop / 142+ Android; Safari 18+ macOS / iOS 18+ |
+| **W2.2** | Universal | Strategy | All modern browsers |
+| **W2.3** | Universal | Strategy | All modern browsers |
+| **W2.4** | Desktop only | Conditional | Desktop |
+| **W2.5** | Universal | Conditional | All modern browsers |
+| **W2.6** | Universal | Conditional | All modern browsers |
+| **W2.7** | Universal | Strategy | All modern browsers |
+| **W2.8** | Universal | Baseline | All modern browsers |
+| **W3.1** | Universal | Baseline | All modern browsers |
+| **W3.2** | Limited | Supporting capability | Chrome/Edge 132+ desktop; Chrome 144+ Android; Safari 26+ |
+| **N1.1** | Universal | Strategy | iOS 16+, Android 9+ with a supporting Credential Manager/provider |
+| **N1.2** | Limited | Enhancement | iOS 16+, Android 15+ |
+| **N1.3** | Universal | Strategy | iOS 16+, Android 9+ with a supporting Credential Manager/provider |
+| **N1.4** | Universal | Baseline | iOS 16+, Android 9+ for passkey paths |
+| **N2.1** | Universal | Strategy | iOS 16+, Android 9+ |
+| **N2.2** | Universal | Strategy | iOS 16+, Android 9+ |
+| **N2.3** | Universal | Conditional | iOS 16+, Android 9+ |
+| **N2.4** | Universal | Strategy | iOS 16+, Android 9+ |
+| **N2.5** | Universal | Strategy | iOS 16+, Android 9+ |
+| **N2.6** | Limited | Enhancement | iOS 18+; Android 9+ with `androidx.credentials` 1.6.0 and a supporting provider |
+| **N3.1** | Universal | Baseline | iOS, Android |
+| **N3.2** | Limited | Supporting capability | Android 15+; Apple 26.0+ with legacy `ASCredentialUpdater` on 26.0–26.1 and current `ASCredentialDataManager` on 26.2+ |
+| **E1** | Universal | Supporting capability | Platform-independent |
+
+</Accordion>
+
+## Using this catalogue
+
+**For implementation reviews:** Declare the target platforms and account policies first, then assess only the applicable strategies and conditional flows with the [benchmarking method](/passkey-ui-flows/benchmarking). Do not use a raw percentage of checked rows.
+
+**For Corbado Connect users:** Map the configured product capabilities to the same acceptance criteria and attach implementation or production evidence. Product availability alone is not evidence that a deployed flow passes.
+
+**For custom implementations:** Use the criteria as outcome requirements. They deliberately avoid prescribing a specific SDK, identity provider or internal architecture.
+
+<Tip>
+    Want the full Figma board with all flows for your design team? Email <a href="mailto:contact@corbado.com">contact@corbado.com</a> to request access.
+</Tip>

--- a/passkey-ui-flows/overview.mdx
+++ b/passkey-ui-flows/overview.mdx
@@ -1,131 +1,47 @@
 ---
 title: "Passkey UI Best Practices"
-description: "Passkey UI best practices, flow diagrams and acceptance criteria for login, creation and management across web and native apps."
+sidebarTitle: "1. Start here"
+description: "A map of the passkey UI flows for web and native apps, the flow catalogue and how to benchmark an implementation against it."
 ---
 
-## Overview
+import { PasskeyLifecycleMap } from "/snippets/passkey-ui-flows/lifecycle-map.mdx";
 
-These UI flow diagrams combine standards and platform guidance with production experience from [Corbado Connect](/corbado-connect/overview/welcome). They provide reference patterns for benchmarking. They do not require the use of Corbado or the implementation of every flow.
+Every passkey flow in this section belongs to one of three moments in a user's life with a passkey. Start with the map, then go as deep as you need.
+
+<PasskeyLifecycleMap />
+
+## What this section is
+
+A catalogue of **28 passkey UI flows** for web and native apps, plus Passkey Intelligence, which decides when they run. Each carries product-neutral acceptance criteria and a method for scoring an implementation against them.
+
+It combines the specifications and platform guidance with production experience from [Corbado Connect](/corbado-connect/overview/welcome). It does **not** require you to use Corbado or to implement every flow.
 
 <Info>
-    **Evidence and implementation:** Each flow has product-neutral acceptance criteria based on specifications, official platform documentation and clearly scoped implementation experience. Corbado Connect is one reference implementation for many of these patterns.
+    **Evidence and implementation:** Each flow's acceptance criteria are based on specifications, official platform documentation and clearly scoped implementation experience. Corbado Connect is one reference implementation for many of these patterns, not the standard being tested.
 </Info>
 
-## What you'll learn
+## Pick your path
 
--   **Login, creation and management flows:** Review the main web and native passkey flows
--   **Decision points:** Review the relevant screens, error states and fallback cases
--   **Platform differences:** Compare passkey behavior on iOS, Android, macOS and Windows
--   **Operational edge cases:** Understand error handling, cross-device use and recovery
--   **Acceptance criteria:** Review implementation requirements and their supporting sources
-
-The documentation uses UI examples and decision trees to explain each scenario and support implementation reviews.
-
-## Flow catalogue
-
-Every flow in this section carries a stable ID. Use these IDs when scoping an implementation, comparing platforms or assessing an existing identity provider.
-
-The prefix identifies the platform and phase: `W` for web and `N` for native, `1` for login, `2` for passkey creation and `3` for management. `E` covers Passkey Intelligence, which is not platform-specific. New flows are appended to the end of their group, so existing IDs never shift.
-
-Use the [benchmarking method](/passkey-ui-flows/benchmarking) to record criterion-level results and determine adoption potential. **Expected adoption impact** estimates the effect on the full authentication funnel. `Low` does not mean unimportant, and the labels must not be added together as a score.
-
-### Web · Login
-
-| ID | Flow | Availability | Use when | Benchmark as | Expected adoption impact |
-| --- | --- | --- | --- | --- | --- |
-| **W1.1** | [One-Tap](/passkey-ui-flows/web/passkey-login/one-tap) | All modern browsers | A returning user should see a single, explicit passkey button | Strategy | High |
-| **W1.2** | [Conditional UI](/passkey-ui-flows/web/passkey-login/conditional-ui) | All modern browsers | You want usernameless login offered inside the identifier field | Enhancement | High |
-| **W1.3** | [Identifier-first](/passkey-ui-flows/web/passkey-login/identifier-first) | All modern browsers | You already run an identifier-first login form | Strategy | High |
-| **W1.4** | [Cross-device via QR](/passkey-ui-flows/web/passkey-login/cross-device-qr) | Desktop; needs Bluetooth and internet | The user's passkey lives on their phone | Conditional | Mid |
-| **W1.5** | [Login error states](/passkey-ui-flows/web/passkey-login/error-states) | All | You are designing failure handling and fallback | Baseline | Mid |
-| **W1.6** | [Immediate mode](/passkey-ui-flows/web/passkey-login/immediate-mode) | Chrome only; feature-detect `immediateGet` | A client has an immediately available credential and should offer a faster login | Enhancement | Mid |
-
-### Web · Passkey creation
-
-| ID | Flow | Availability | Use when | Benchmark as | Expected adoption impact |
-| --- | --- | --- | --- | --- | --- |
-| **W2.1** | [Automatic upgrade (conditional create)](/passkey-ui-flows/web/passkey-creation/automatic-upgrade) | Chrome 136+ desktop / 142+ Android; Safari 18+ macOS / iOS 18+ | A password was just filled by the user's credential manager | Enhancement | Mid |
-| **W2.2** | [After login, non-MFA (post-login nudge)](/passkey-ui-flows/web/passkey-creation/non-mfa) | All modern browsers | A single-factor account should be offered a passkey after login | Strategy | High |
-| **W2.3** | [After login, MFA (post-login nudge)](/passkey-ui-flows/web/passkey-creation/mfa) | All modern browsers | An MFA account should be offered a passkey after verification | Strategy | High |
-| **W2.4** | [After hybrid login](/passkey-ui-flows/web/passkey-creation/after-hybrid) | Desktop | The user just signed in by scanning a QR code | Conditional | Mid |
-| **W2.5** | [After passkey error (add a usable passkey)](/passkey-ui-flows/web/passkey-creation/after-error) | All modern browsers | A passkey attempt failed and verified fallback creates another usable credential | Conditional | Mid |
-| **W2.6** | [On 2nd device](/passkey-ui-flows/web/passkey-creation/on-2nd-device) | All modern browsers | The account's passkeys were created before this device was first seen | Conditional | Mid |
-| **W2.7** | [During sign-up](/passkey-ui-flows/web/sign-up) | All modern browsers | A new account should create a passkey during registration | Strategy | Mid |
-| **W2.8** | [Creation cancellation](/passkey-ui-flows/web/passkey-creation/cancellation) | All modern browsers | An explicit creation offer can be skipped or its system ceremony cancelled | Baseline | Mid |
-
-### Web · Management
-
-| ID | Flow | Availability | Use when | Benchmark as | Expected adoption impact |
-| --- | --- | --- | --- | --- | --- |
-| **W3.1** | [Passkey management](/passkey-ui-flows/web/passkey-management) | All modern browsers | Users need to list, add and revoke their own passkeys | Baseline | Low |
-| **W3.2** | [WebAuthn Signal API](/passkey-ui-flows/web/signal-api) | Chrome/Edge 132+ desktop; Chrome 144+ Android; Safari 26+ | Keeping the credential manager in sync with what your server accepts | Supporting capability | Low |
-
-### Native · Login
-
-| ID | Flow | Availability | Use when | Benchmark as | Expected adoption impact |
-| --- | --- | --- | --- | --- | --- |
-| **N1.1** | [App-start overlay](/passkey-ui-flows/native/passkey-login/overlay) | iOS 16+, Android 9+ with a supporting Credential Manager/provider | The app should offer a passkey before the user types anything | Strategy | High |
-| **N1.2** | [Conditional UI](/passkey-ui-flows/native/passkey-login/conditional-ui) | iOS 16+, Android 15+ | You want passkeys suggested from the keyboard | Enhancement | Mid |
-| **N1.3** | [Identifier-first](/passkey-ui-flows/native/passkey-login/identifier-first) | iOS 16+, Android 9+ with a supporting Credential Manager/provider | The app collects an identifier before authenticating | Strategy | High |
-| **N1.4** | [Login error states](/passkey-ui-flows/native/passkey-login/error-states) | iOS 16+, Android 9+ for passkey paths | You need recoverable, platform-aware failure handling | Baseline | Mid |
-
-### Native · Passkey creation
-
-| ID | Flow | Availability | Use when | Benchmark as | Expected adoption impact |
-| --- | --- | --- | --- | --- | --- |
-| **N2.1** | [After login, non-MFA (post-login nudge)](/passkey-ui-flows/native/passkey-creation/non-mfa) | iOS 16+, Android 9+ | A single-factor account should be offered a passkey after login | Strategy | High |
-| **N2.2** | [After login, MFA (post-login nudge)](/passkey-ui-flows/native/passkey-creation/mfa) | iOS 16+, Android 9+ | An MFA account should be offered a passkey after verification | Strategy | High |
-| **N2.3** | [After passkey error (add a usable passkey)](/passkey-ui-flows/native/passkey-creation/after-error) | iOS 16+, Android 9+ | A failed passkey attempt is followed by verified fallback and another usable credential | Conditional | Mid |
-| **N2.4** | [In-app nudge after unlock](/passkey-ui-flows/native/passkey-creation/in-app-after-unlock) | iOS 16+, Android 9+ | Long-lived sessions make post-login enrollment rare | Strategy | Mid |
-| **N2.5** | [In-app nudge on key action](/passkey-ui-flows/native/passkey-creation/in-app-after-cta) | iOS 16+, Android 9+ | A relevant completed action provides a less disruptive time for enrollment | Strategy | Mid |
-| **N2.6** | [Automatic upgrade (conditional create)](/passkey-ui-flows/native/passkey-creation/automatic-upgrade) | iOS 18+; Android 9+ with `androidx.credentials` 1.6.0 and a supporting provider | A password was just filled by the user's credential manager in your app | Enhancement | Mid |
-
-### Native · Management
-
-| ID | Flow | Availability | Use when | Benchmark as | Expected adoption impact |
-| --- | --- | --- | --- | --- | --- |
-| **N3.1** | [Passkey management](/passkey-ui-flows/native/passkey-management) | iOS, Android | Users need to list, add and revoke their own passkeys | Baseline | Low |
-| **N3.2** | [WebAuthn Signal API](/passkey-ui-flows/native/signal-api) | Android 15+; Apple 26.0+ with legacy `ASCredentialUpdater` on 26.0–26.1 and current `ASCredentialDataManager` on 26.2+ | Keeping the credential manager in sync with what your server accepts | Supporting capability | Low |
-
-### Passkey Intelligence
-
-This is not a separate UI flow. It helps decide *whether* one of the flows above should run. The benchmark checks the resulting behavior and does not require a proprietary engine.
-
-| ID | Capability | What it decides | Benchmark as | Expected adoption impact |
-| --- | --- | --- | --- | --- |
-| **E1** | [Passkey Intelligence](/passkey-ui-flows/passkey-intelligence) | Whether to attempt, offer, defer or fall back from a passkey flow in the current context | Supporting capability | High |
-
-## UI Flow Categories
-
-<CardGroup cols={2}>
-<Card title="Web UI Flows" icon="globe" href="/passkey-ui-flows/web/passkey-login/one-tap">
-    Web patterns for login methods, passkey creation, error handling and passkey management.
+<CardGroup cols={3}>
+<Card title="Design a flow" icon="pen-ruler" href="/passkey-ui-flows/flow-catalogue">
+    Browse the catalogue, pick the flows that fit your product and use the screens and decision trees on each flow page.
 </Card>
 
-<Card title="Native App UI Flows" icon="mobile" href="/passkey-ui-flows/native/passkey-login/overlay">
-    Native app patterns for platform-specific authentication, local biometric protection and passkey prompts in long-lived sessions.
+<Card title="Review or compare" icon="clipboard-check" href="/passkey-ui-flows/benchmarking">
+    Grade what you have shipped, or score two identity providers under identical conditions, and get an adoption-potential rating.
+</Card>
+
+<Card title="Decide when flows run" icon="brain" href="/passkey-ui-flows/passkey-intelligence">
+    Work out when to attempt a passkey automatically, when to offer one, when to wait and when to fall back.
 </Card>
 </CardGroup>
 
 <Note>
-    In this documentation, MFA is not mandatory by default. This means
-    single-factor accounts (e.g., accounts secured only with a password) are
-    supported. However, MFA can be enforced if required by the application or
-    compliance. When MFA is optional, the passkey append option allows users who
-    initially registered without MFA to later add additional factors for
-    stronger security.
+    In this documentation, MFA is not mandatory by default. Single-factor accounts (e.g. accounts secured only with a password) are supported, but MFA can be enforced where the application or compliance requires it. When MFA is optional, the passkey append option lets users who initially registered without MFA add additional factors later.
 </Note>
 
-## Using These Flows
-
-**For implementation reviews:** Declare the target platforms and account policies first, then assess only applicable strategies and conditional flows with the [benchmarking method](/passkey-ui-flows/benchmarking). Do not use a raw percentage of checked rows.
-
-**For Corbado Connect users:** Map the configured product capabilities to the same acceptance criteria and attach implementation or production evidence. Product availability alone is not evidence that a deployed flow passes.
-
-**For custom implementations:** Use the criteria as outcome requirements. They deliberately avoid prescribing a specific SDK, identity provider or internal architecture.
-
 <Tip>
-    Want access to the full Figma board with all flows for your design team? Email <a href="mailto:contact@corbado.com">contact@corbado.com</a> to request access.
+    Want the full Figma board with all flows for your design team? Email <a href="mailto:contact@corbado.com">contact@corbado.com</a> to request access.
 </Tip>
 
 import CognitoDemo from "/snippets/corbado-connect/cognito-demo.mdx";

--- a/passkey-ui-flows/passkey-intelligence.mdx
+++ b/passkey-ui-flows/passkey-intelligence.mdx
@@ -1,26 +1,19 @@
 ---
 title: "Passkey Intelligence"
+sidebarTitle: "4. Passkey Intelligence"
 description: "How Passkey Intelligence uses client, credential and journey signals to target passkey login, creation, cross-device authentication and fallback."
 ---
 
+import { PasskeyDecisionMap } from "/snippets/passkey-ui-flows/decision-map.mdx";
 import E1AcceptanceCriteria from "/snippets/passkey-ui-flows/acceptance-criteria/e1.mdx";
 
-The name **Passkey Intelligence** is taken from Corbado Connect. In this benchmark, it is used more broadly for the capability that decides whether to start a ceremony automatically, show a passkey action, wait or continue with fallback. The benchmark checks the resulting behavior, not a particular product or architecture.
+Before any passkey UI appears, something has to decide whether it should. Showing a passkey button to a user who has no usable passkey is the fastest way to make passkeys look broken.
 
-## Measurement
+Passkey Intelligence is the capability that makes that call. It reads the current context and picks one of four actions.
 
-Passkey Intelligence starts with detailed journey and environment data. It should be possible to follow a user from the targeting decision through the passkey or fallback result and, after creation, to later passkey use.
+<PasskeyDecisionMap />
 
-| Area | Record |
-| --- | --- |
-| **Decision** | Selected action and flow, reason, account group, nudge count and active cooldown |
-| **Journey** | Eligibility check, offer shown, user action, ceremony start, success, cancellation, error, fallback start and fallback success |
-| **Credential** | Creation, later use, credential ID, AAGUID or provider label, authenticator attachment, stored transports and backup state where returned |
-| **Environment** | Web or native, browser or app version, operating system and version, device class and model where available, User-Agent or Client Hints, capability results and first-party environment history |
-
-Some environment values are unavailable or reduced on certain clients. Keep those values unknown instead of inventing precision.
-
-## Decision actions
+## 1. What it decides
 
 | Action | Meaning |
 | --- | --- |
@@ -29,7 +22,21 @@ Some environment values are unavailable or reduced on certain clients. Keep thos
 | **Defer** | Do not show an optional passkey prompt in the current context. |
 | **Fallback** | Continue with another login or recovery method. |
 
-## Creation targeting
+Everything below is how that decision is reached for each situation, and what to record afterwards.
+
+## 2. Deciding for login
+
+For identifier-first login, an account must have at least one accepted passkey before Passkey Intelligence selects an account-specific passkey route. That server record does not prove that the passkey is available from the current client.
+
+| Availability estimate | Action |
+| --- | --- |
+| A usable passkey is likely available from the current client | **Attempt** the selected passkey login automatically. |
+| The account has a passkey, but current availability is uncertain | **Offer** an explicit passkey action. |
+| The account has no passkey or the intended route is unlikely to work | Continue with **fallback** without opening a passkey ceremony expected to fail. |
+
+When availability is uncertain, an explicit passkey route can remain available through **Offer**. When the intended route is unlikely to work, start fallback login immediately.
+
+## 3. Deciding for creation
 
 Before showing a broad post-login creation nudge, check that the current client can likely create a passkey that is usable from this environment without another device or security key. On the web, platform-authenticator availability and client capabilities are useful inputs, but they do not guarantee that a credential provider will accept the request.
 
@@ -46,26 +53,31 @@ Passkey Intelligence should also recognize the situations covered by the more sp
 
 Creation nudges use one account-level history across post-login, signup and in-app entry points that target the same enrollment goal. Cancellation and explicit skip can have different cooldowns. Multiple nudges across separate eligible sessions are the default until the goal succeeds, while daily, monthly or yearly limits apply across every entry point.
 
-## Login targeting
-
-For identifier-first login, an account must have at least one accepted passkey before Passkey Intelligence selects an account-specific passkey route. That server record does not prove that the passkey is available from the current client.
-
-| Availability estimate | Action |
-| --- | --- |
-| A usable passkey is likely available from the current client | **Attempt** the selected passkey login automatically. |
-| The account has a passkey, but current availability is uncertain | **Offer** an explicit passkey action. |
-| The account has no passkey or the intended route is unlikely to work | Continue with **fallback** without opening a passkey ceremony expected to fail. |
-
-When availability is uncertain, an explicit passkey route can remain available through **Offer**. When the intended route is unlikely to work, start fallback login immediately.
-
-## Cross-device and security-key routes
+## 4. Cross-device and security-key routes
 
 When a cross-device route is likely, prepare the user before opening the system experience. Explain that a phone and QR code will be used. Name a device or provider only when account-specific history supports that wording and the information is still applicable.
 
 Transport and attachment data have different roles. During authentication, use the account's credential descriptors, stored `transports` and supported request `hints` to guide client-device, `hybrid` or `security-key` routes. `authenticatorAttachment` is not an authentication request selector. During creation, `authenticatorSelection.authenticatorAttachment` can prefer `platform` or `cross-platform`, or it can be left unset so the client can choose. An unset value is not a third authenticator type.
 
+## 5. What to measure
+
+Passkey Intelligence starts with detailed journey and environment data. It should be possible to follow a user from the targeting decision through the passkey or fallback result and, after creation, to later passkey use.
+
+| Area | Record |
+| --- | --- |
+| **Decision** | Selected action and flow, reason, account group, nudge count and active cooldown |
+| **Journey** | Eligibility check, offer shown, user action, ceremony start, success, cancellation, error, fallback start and fallback success |
+| **Credential** | Creation, later use, credential ID, AAGUID or provider label, authenticator attachment, stored transports and backup state where returned |
+| **Environment** | Web or native, browser or app version, operating system and version, device class and model where available, User-Agent or Client Hints, capability results and first-party environment history |
+
+Some environment values are unavailable or reduced on certain clients. Keep those values unknown instead of inventing precision.
+
 <E1AcceptanceCriteria />
 
 ## Reference implementation
+
+<Info>
+    **About the name:** **Passkey Intelligence** is taken from Corbado Connect. In this benchmark it is used more broadly for the capability that decides whether to start a ceremony automatically, show a passkey action, wait or continue with fallback. The benchmark checks the resulting behavior, not a particular product or architecture.
+</Info>
 
 [Corbado Connect Passkey Intelligence](/corbado-connect/features/passkey-intelligence) is the implementation from which the name is taken. Other implementations can satisfy the same acceptance criteria without using its internal signals or architecture.

--- a/snippets/passkey-ui-flows/acceptance-criteria/e1.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/e1.mdx
@@ -1,7 +1,7 @@
 ## Acceptance criteria
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Supporting capability | High |
 

--- a/snippets/passkey-ui-flows/acceptance-criteria/n1-1.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/n1-1.mdx
@@ -1,7 +1,7 @@
 ## Acceptance criteria
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Strategy | High |
 

--- a/snippets/passkey-ui-flows/acceptance-criteria/n1-2.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/n1-2.mdx
@@ -1,7 +1,7 @@
 ## Acceptance criteria
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Enhancement | Mid |
 

--- a/snippets/passkey-ui-flows/acceptance-criteria/n1-3.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/n1-3.mdx
@@ -1,7 +1,7 @@
 ## Acceptance criteria
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Strategy | High |
 

--- a/snippets/passkey-ui-flows/acceptance-criteria/n1-4.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/n1-4.mdx
@@ -1,7 +1,7 @@
 ## Acceptance criteria
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Baseline | Mid |
 

--- a/snippets/passkey-ui-flows/acceptance-criteria/n2-1.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/n2-1.mdx
@@ -1,7 +1,7 @@
 ## Acceptance criteria
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Strategy | High |
 

--- a/snippets/passkey-ui-flows/acceptance-criteria/n2-2.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/n2-2.mdx
@@ -1,7 +1,7 @@
 ## Acceptance criteria
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Strategy | High |
 

--- a/snippets/passkey-ui-flows/acceptance-criteria/n2-3.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/n2-3.mdx
@@ -1,7 +1,7 @@
 ## Acceptance criteria
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Conditional | Mid |
 

--- a/snippets/passkey-ui-flows/acceptance-criteria/n2-4.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/n2-4.mdx
@@ -1,7 +1,7 @@
 ## Acceptance criteria
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Strategy | Mid |
 

--- a/snippets/passkey-ui-flows/acceptance-criteria/n2-5.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/n2-5.mdx
@@ -1,7 +1,7 @@
 ## Acceptance criteria
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Strategy | Mid |
 

--- a/snippets/passkey-ui-flows/acceptance-criteria/n2-6.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/n2-6.mdx
@@ -1,7 +1,7 @@
 ## Acceptance criteria
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Enhancement | Mid |
 

--- a/snippets/passkey-ui-flows/acceptance-criteria/n3-1.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/n3-1.mdx
@@ -1,11 +1,11 @@
 ## Acceptance criteria
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Baseline | Low |
 
-Low expected adoption impact does not mean low importance. Native passkey management is a baseline lifecycle and security capability, while proactive creation and login flows usually have more direct influence on adoption.
+Low user reach does not mean low importance. Native passkey management is a baseline lifecycle and security capability, while proactive creation and login flows usually have more direct influence on adoption.
 
 
 | ID | Level | Acceptance criterion | How to verify |

--- a/snippets/passkey-ui-flows/acceptance-criteria/n3-2.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/n3-2.mdx
@@ -1,7 +1,7 @@
 ## Acceptance criteria
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Supporting capability | Low |
 

--- a/snippets/passkey-ui-flows/acceptance-criteria/w1-1.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/w1-1.mdx
@@ -2,7 +2,7 @@
 
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Strategy | High |
 

--- a/snippets/passkey-ui-flows/acceptance-criteria/w1-2.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/w1-2.mdx
@@ -2,7 +2,7 @@
 
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Enhancement | High |
 

--- a/snippets/passkey-ui-flows/acceptance-criteria/w1-3.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/w1-3.mdx
@@ -1,11 +1,11 @@
 ## Acceptance criteria
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Strategy | High |
 
-Identifier-first has a High expected adoption impact only when automatic passkey prompts are selective and the fallback remains predictable.
+Identifier-first has a High user reach only when automatic passkey prompts are selective and the fallback remains predictable.
 
 
 | ID | Level | Acceptance criterion | How to verify |

--- a/snippets/passkey-ui-flows/acceptance-criteria/w1-4.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/w1-4.mdx
@@ -1,7 +1,7 @@
 ## Acceptance criteria
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Conditional | Mid |
 

--- a/snippets/passkey-ui-flows/acceptance-criteria/w1-5.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/w1-5.mdx
@@ -1,7 +1,7 @@
 ## Acceptance criteria
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Baseline | Mid |
 

--- a/snippets/passkey-ui-flows/acceptance-criteria/w1-6.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/w1-6.mdx
@@ -1,7 +1,7 @@
 ## Acceptance criteria
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Enhancement | Mid |
 

--- a/snippets/passkey-ui-flows/acceptance-criteria/w2-1.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/w2-1.mdx
@@ -1,7 +1,7 @@
 ## Acceptance criteria
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Enhancement | Mid |
 

--- a/snippets/passkey-ui-flows/acceptance-criteria/w2-2.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/w2-2.mdx
@@ -2,7 +2,7 @@
 
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Strategy | High |
 

--- a/snippets/passkey-ui-flows/acceptance-criteria/w2-3.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/w2-3.mdx
@@ -2,7 +2,7 @@
 
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Strategy | High |
 

--- a/snippets/passkey-ui-flows/acceptance-criteria/w2-4.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/w2-4.mdx
@@ -1,7 +1,7 @@
 ## Acceptance criteria
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Conditional | Mid |
 

--- a/snippets/passkey-ui-flows/acceptance-criteria/w2-5.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/w2-5.mdx
@@ -2,7 +2,7 @@
 
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Conditional | Mid |
 

--- a/snippets/passkey-ui-flows/acceptance-criteria/w2-6.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/w2-6.mdx
@@ -1,7 +1,7 @@
 ## Acceptance criteria
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Conditional | Mid |
 

--- a/snippets/passkey-ui-flows/acceptance-criteria/w2-7.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/w2-7.mdx
@@ -1,6 +1,6 @@
 ## Acceptance criteria
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Strategy | Mid |
 

--- a/snippets/passkey-ui-flows/acceptance-criteria/w2-8.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/w2-8.mdx
@@ -1,6 +1,6 @@
 ## Acceptance criteria
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Baseline | Mid |
 

--- a/snippets/passkey-ui-flows/acceptance-criteria/w3-1.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/w3-1.mdx
@@ -1,11 +1,11 @@
 ## Acceptance criteria
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Baseline | Low |
 
-Low expected adoption impact does not mean low importance. Passkey management is a baseline lifecycle and security capability: it gives users control over registered credentials and protects account continuity when a credential is lost or no longer trusted.
+Low user reach does not mean low importance. Passkey management is a baseline lifecycle and security capability: it gives users control over registered credentials and protects account continuity when a credential is lost or no longer trusted.
 
 
 | ID | Level | Acceptance criterion | How to verify |

--- a/snippets/passkey-ui-flows/acceptance-criteria/w3-2.mdx
+++ b/snippets/passkey-ui-flows/acceptance-criteria/w3-2.mdx
@@ -1,11 +1,11 @@
 ## Acceptance criteria
 
 
-| Benchmark as | Expected adoption impact |
+| Benchmark as | User reach |
 | --- | --- |
 | Supporting capability | Low |
 
-Low expected adoption impact does not mean low reliability importance. Signalling does not itself create or promote passkeys, but it reduces stale credential choices and repeated post-verification failures across login and management flows.
+Low user reach does not mean low reliability importance. Signalling does not itself create or promote passkeys, but it reduces stale credential choices and repeated post-verification failures across login and management flows.
 
 The Signal API is intentionally privacy-preserving and opportunistic. Acceptance can verify the relying party's trigger, payload and error handling, but must never require confirmation that a credential provider updated, hid or removed a passkey.
 

--- a/snippets/passkey-ui-flows/decision-map.mdx
+++ b/snippets/passkey-ui-flows/decision-map.mdx
@@ -1,0 +1,82 @@
+export const PasskeyDecisionMap = () => {
+    const signals = ["Client and device", "Existing credentials", "Journey history", "Prior attempts"];
+    const actions = [
+        { y: 14, name: "Attempt", desc: "Start the ceremony now" },
+        { y: 58, name: "Offer", desc: "Show a passkey action" },
+        { y: 102, name: "Defer", desc: "Do not prompt in this context" },
+        { y: 146, name: "Fall back", desc: "Continue with another method" },
+    ];
+
+    return (
+        <svg
+            viewBox="0 0 596 198"
+            role="img"
+            aria-label="Passkey Intelligence takes client, credential and journey signals, decides whether a usable passkey is reachable, and picks attempt, offer, defer or fall back"
+            style={{ width: "100%", maxWidth: "596px", height: "auto", margin: "0 auto", display: "block", color: "inherit" }}
+        >
+            <title>How Passkey Intelligence decides</title>
+
+            <defs>
+                <marker id="pkDecideArrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+                    <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor" opacity="0.45" />
+                </marker>
+            </defs>
+
+            <rect
+                x="8" y="14" width="150" height="170" rx="11"
+                fill="currentColor" fillOpacity="0.045"
+                stroke="currentColor" strokeOpacity="0.22"
+            />
+            <text x="24" y="46" fontSize="14" fontWeight="600" fill="currentColor">
+                Signals
+            </text>
+            {signals.map((s, i) => (
+                <text key={s} x="24" y={74 + i * 20} fontSize="11" fill="currentColor" fillOpacity="0.65">
+                    {s}
+                </text>
+            ))}
+
+            <line x1="162" y1="99" x2="188" y2="99" stroke="currentColor" strokeOpacity="0.45" strokeWidth="1.5" markerEnd="url(#pkDecideArrow)" />
+
+            <rect
+                x="196" y="14" width="150" height="170" rx="11"
+                fill="currentColor" fillOpacity="0.045"
+                stroke="currentColor" strokeOpacity="0.22"
+            />
+            <circle cx="228" cy="46" r="14" className="pk-accent" />
+            <text x="228" y="50" textAnchor="middle" fontSize="11" fontWeight="700" fill="#ffffff">
+                E1
+            </text>
+            <text x="250" y="51" fontSize="14" fontWeight="600" fill="currentColor">
+                Decide
+            </text>
+            <text x="212" y="88" fontSize="11.5" fill="currentColor" fillOpacity="0.7">
+                Is a usable passkey
+            </text>
+            <text x="212" y="106" fontSize="11.5" fill="currentColor" fillOpacity="0.7">
+                reachable from this
+            </text>
+            <text x="212" y="124" fontSize="11.5" fill="currentColor" fillOpacity="0.7">
+                client right now?
+            </text>
+
+            <line x1="350" y1="99" x2="376" y2="99" stroke="currentColor" strokeOpacity="0.45" strokeWidth="1.5" markerEnd="url(#pkDecideArrow)" />
+
+            {actions.map((a) => (
+                <g key={a.name}>
+                    <rect
+                        x="384" y={a.y} width="204" height="38" rx="9"
+                        fill="currentColor" fillOpacity="0.045"
+                        stroke="currentColor" strokeOpacity="0.22"
+                    />
+                    <text x="398" y={a.y + 17} fontSize="12.5" fontWeight="600" fill="currentColor">
+                        {a.name}
+                    </text>
+                    <text x="398" y={a.y + 31} fontSize="10" fill="currentColor" fillOpacity="0.6">
+                        {a.desc}
+                    </text>
+                </g>
+            ))}
+        </svg>
+    );
+};

--- a/snippets/passkey-ui-flows/legend-availability.mdx
+++ b/snippets/passkey-ui-flows/legend-availability.mdx
@@ -1,0 +1,7 @@
+| Value | Meaning |
+| --- | --- |
+| **Universal** | Works on every modern browser or on iOS 16+ / Android 9+ with a supporting credential provider. |
+| **Limited** | Depends on recent browser, OS or provider versions. Feature-detect and degrade gracefully. |
+| **Desktop only** | Applies to the desktop context by definition. |
+
+Exact version requirements are listed on each flow page and in the [availability matrix](/passkey-ui-flows/flow-catalogue#availability-matrix).

--- a/snippets/passkey-ui-flows/legend-benchmark-as.mdx
+++ b/snippets/passkey-ui-flows/legend-benchmark-as.mdx
@@ -1,0 +1,7 @@
+| Value | Meaning |
+| --- | --- |
+| **Baseline** | Expected production behavior whenever passkeys are in scope. |
+| **Strategy** | One primary UX pattern that can coexist with or substitute for another strategy. Do not require every alternative. |
+| **Conditional** | Required only when its documented scenario occurs in the declared scope. |
+| **Enhancement** | Progressive capability that improves the flow where supported; unsupported targets are not penalized. |
+| **Supporting capability** | Non-UI behavior that improves several flows. |

--- a/snippets/passkey-ui-flows/legend-user-reach.mdx
+++ b/snippets/passkey-ui-flows/legend-user-reach.mdx
@@ -1,0 +1,7 @@
+| Value | Meaning |
+| --- | --- |
+| **High** | Directly affects a frequent, broad creation or returning-login opportunity. |
+| **Mid** | Expands device coverage, recovery or another important part of the user base. |
+| **Low** | Primarily improves lifecycle hygiene, trust or administration rather than direct funnel exposure. |
+
+This is a qualitative estimate for the full audience. It is **not** a measure of overall importance, it does not affect whether a criterion passes and the labels must never be added together as a score. Credential management and Signal API reconciliation have low user reach but high reliability and lifecycle value.

--- a/snippets/passkey-ui-flows/lifecycle-map.mdx
+++ b/snippets/passkey-ui-flows/lifecycle-map.mdx
@@ -1,0 +1,98 @@
+export const PasskeyLifecycleMap = () => {
+    const phases = [
+        {
+            x: 8,
+            num: "2",
+            title: "Create",
+            desc: "Enroll a passkey",
+            ids: "W2.1–W2.8 · N2.1–N2.6",
+            href: "/passkey-ui-flows/flow-catalogue#2-passkey-creation",
+        },
+        {
+            x: 212,
+            num: "1",
+            title: "Log in",
+            desc: "Sign in with it",
+            ids: "W1.1–W1.6 · N1.1–N1.4",
+            href: "/passkey-ui-flows/flow-catalogue#1-passkey-login",
+        },
+        {
+            x: 416,
+            num: "3",
+            title: "Manage",
+            desc: "List, add, revoke",
+            ids: "W3.1–W3.2 · N3.1–N3.2",
+            href: "/passkey-ui-flows/flow-catalogue#3-passkey-management",
+        },
+    ];
+
+    return (
+        <svg
+            viewBox="0 0 596 262"
+            role="img"
+            aria-label="Passkey flow lifecycle: create, log in and manage, with Passkey Intelligence deciding whether each flow runs"
+            style={{ width: "100%", maxWidth: "596px", height: "auto", margin: "0 auto", display: "block", color: "inherit" }}
+        >
+            <title>Passkey UI flow lifecycle</title>
+
+            <defs>
+                <marker id="pkArrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+                    <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor" opacity="0.45" />
+                </marker>
+            </defs>
+
+            {phases.map((p) => (
+                <a href={p.href} key={p.num} className="pk-node">
+                    <rect
+                        x={p.x} y="24" width="172" height="112" rx="11"
+                        fill="currentColor" fillOpacity="0.045"
+                        stroke="currentColor" strokeOpacity="0.22"
+                    />
+                    <circle cx={p.x + 26} cy="54" r="14" className="pk-accent" />
+                    <text x={p.x + 26} y="59" textAnchor="middle" fontSize="14" fontWeight="700" fill="#ffffff">
+                        {p.num}
+                    </text>
+                    <text x={p.x + 48} y="60" fontSize="17" fontWeight="600" fill="currentColor">
+                        {p.title}
+                    </text>
+                    <text x={p.x + 16} y="90" fontSize="12.5" fill="currentColor" fillOpacity="0.72">
+                        {p.desc}
+                    </text>
+                    <text x={p.x + 16} y="115" fontSize="11" fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace" fill="currentColor" fillOpacity="0.5">
+                        {p.ids}
+                    </text>
+                </a>
+            ))}
+
+            <line x1="184" y1="80" x2="208" y2="80" stroke="currentColor" strokeOpacity="0.45" strokeWidth="1.5" markerEnd="url(#pkArrow)" />
+            <line x1="388" y1="80" x2="412" y2="80" stroke="currentColor" strokeOpacity="0.45" strokeWidth="1.5" markerEnd="url(#pkArrow)" />
+
+            <path
+                d="M 298 136 L 298 164 L 100 164 L 100 142"
+                fill="none" stroke="currentColor" strokeOpacity="0.35" strokeWidth="1.5"
+                strokeDasharray="4 4" markerEnd="url(#pkArrow)"
+            />
+            <text x="199" y="183" textAnchor="middle" fontSize="11.5" fill="currentColor" fillOpacity="0.6">
+                re-offer after an error or on a 2nd device
+            </text>
+
+            <a href="/passkey-ui-flows/passkey-intelligence" className="pk-node">
+                <rect
+                    x="8" y="196" width="580" height="52" rx="11"
+                    fill="currentColor" fillOpacity="0.045"
+                    stroke="currentColor" strokeOpacity="0.22" strokeDasharray="6 4"
+                />
+                <circle cx="40" cy="222" r="14" className="pk-accent" />
+                <text x="40" y="226" textAnchor="middle" fontSize="11" fontWeight="700" fill="#ffffff">
+                    E1
+                </text>
+                <text x="64" y="218" fontSize="14" fontWeight="600" fill="currentColor">
+                    Passkey Intelligence
+                </text>
+                <text x="64" y="237" fontSize="11.5" fill="currentColor" fillOpacity="0.7">
+                    Decides whether a flow runs automatically, is offered, deferred or falls back
+                </text>
+            </a>
+        </svg>
+    );
+};

--- a/snippets/passkey-ui-flows/metadata-legend.mdx
+++ b/snippets/passkey-ui-flows/metadata-legend.mdx
@@ -1,0 +1,17 @@
+import LegendBenchmarkAs from "/snippets/passkey-ui-flows/legend-benchmark-as.mdx";
+import LegendUserReach from "/snippets/passkey-ui-flows/legend-user-reach.mdx";
+import LegendAvailability from "/snippets/passkey-ui-flows/legend-availability.mdx";
+
+<AccordionGroup>
+<Accordion title="Benchmark as: how strictly a flow is judged">
+    <LegendBenchmarkAs />
+</Accordion>
+
+<Accordion title="User reach: how much of the user base a flow touches">
+    <LegendUserReach />
+</Accordion>
+
+<Accordion title="Availability: where the flow can work at all">
+    <LegendAvailability />
+</Accordion>
+</AccordionGroup>

--- a/snippets/passkey-ui-flows/rating-ladder.mdx
+++ b/snippets/passkey-ui-flows/rating-ladder.mdx
@@ -1,0 +1,114 @@
+export const BenchmarkRatingLadder = () => {
+    const rungs = [
+        { x: 8, step: "1", title: ["Scope"], values: ["What you", "reviewed"], mono: false, dashed: true },
+        { x: 126, step: "2", title: ["Criterion"], values: ["Pass", "Fail", "N/A", "Not reviewed"] },
+        { x: 244, step: "3", title: ["Flow"], values: ["Full", "Core met", "Not met", "N/A"] },
+        { x: 362, step: "4", title: ["Pillar"], values: ["Basic", "Managed", "Optimized"] },
+        { x: 480, step: "5", title: ["Adoption", "potential"], values: ["Low", "Mid", "High", "Incomplete"] },
+    ];
+
+    return (
+        <svg
+            viewBox="0 0 594 170"
+            role="img"
+            aria-label="Benchmark method: define scope, then criterion results roll up to a flow rating, then to a pillar level, then to overall adoption potential"
+            style={{ width: "100%", maxWidth: "594px", height: "auto", margin: "0 auto", display: "block", color: "inherit" }}
+        >
+            <title>How the benchmark ratings roll up</title>
+
+            <defs>
+                <marker id="pkLadderArrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+                    <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor" opacity="0.45" />
+                </marker>
+            </defs>
+
+            {rungs.map((r, i) => (
+                <g key={r.step}>
+                    <rect
+                        x={r.x} y="12" width="104" height="144" rx="11"
+                        fill="currentColor" fillOpacity="0.045"
+                        stroke="currentColor" strokeOpacity="0.22"
+                        strokeDasharray={r.dashed ? "6 4" : undefined}
+                    />
+                    <text x={r.x + 12} y="34" fontSize="10" fontWeight="700" className="pk-accent-text" letterSpacing="0.08em">
+                        {"STEP " + r.step}
+                    </text>
+                    {r.title.map((t, k) => (
+                        <text key={t} x={r.x + 12} y={54 + k * 16} fontSize="13.5" fontWeight="600" fill="currentColor">
+                            {t}
+                        </text>
+                    ))}
+                    {r.values.map((v, j) => (
+                        <text
+                            key={v}
+                            x={r.x + 12}
+                            y={82 + (r.title.length - 1) * 16 + j * 14}
+                            fontSize="10.5"
+                            fontFamily={r.mono === false ? undefined : "ui-monospace, SFMono-Regular, Menlo, monospace"}
+                            fill="currentColor"
+                            fillOpacity="0.6"
+                        >
+                            {v}
+                        </text>
+                    ))}
+                    {i < rungs.length - 1 && (
+                        <line
+                            x1={r.x + 108} y1="84" x2={r.x + 122} y2="84"
+                            stroke="currentColor" strokeOpacity="0.45" strokeWidth="1.5"
+                            markerEnd="url(#pkLadderArrow)"
+                        />
+                    )}
+                </g>
+            ))}
+        </svg>
+    );
+};
+
+export const AdoptionPillars = () => {
+    const pillars = [
+        { x: 8, name: "Readiness", q: "Can it work here?" },
+        { x: 158, name: "Enrollment", q: "Do users get one?" },
+        { x: 308, name: "Availability", q: "Can they reach it?" },
+        { x: 458, name: "Usage", q: "Do they use it?" },
+    ];
+
+    return (
+        <svg
+            viewBox="0 0 594 88"
+            role="img"
+            aria-label="The four adoption pillars in order: readiness, enrollment, availability, usage"
+            style={{ width: "100%", maxWidth: "594px", height: "auto", margin: "0 auto", display: "block", color: "inherit" }}
+        >
+            <title>The four adoption pillars</title>
+
+            <defs>
+                <marker id="pkPillarArrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+                    <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor" opacity="0.45" />
+                </marker>
+            </defs>
+
+            {pillars.map((p, i) => (
+                <g key={p.name}>
+                    <rect
+                        x={p.x} y="12" width="128" height="64" rx="11"
+                        fill="currentColor" fillOpacity="0.045"
+                        stroke="currentColor" strokeOpacity="0.22"
+                    />
+                    <text x={p.x + 14} y="40" fontSize="13.5" fontWeight="600" fill="currentColor">
+                        {p.name}
+                    </text>
+                    <text x={p.x + 14} y="60" fontSize="10.5" fill="currentColor" fillOpacity="0.65">
+                        {p.q}
+                    </text>
+                    {i < pillars.length - 1 && (
+                        <line
+                            x1={p.x + 132} y1="44" x2={p.x + 154} y2="44"
+                            stroke="currentColor" strokeOpacity="0.45" strokeWidth="1.5"
+                            markerEnd="url(#pkPillarArrow)"
+                        />
+                    )}
+                </g>
+            ))}
+        </svg>
+    );
+};

--- a/style.css
+++ b/style.css
@@ -1,3 +1,29 @@
 html {
   scroll-behavior: smooth !important;
 }
+
+/* Passkey UI flow diagrams (lifecycle map, rating ladder, adoption pillars) */
+.pk-accent {
+  fill: #184aff;
+}
+
+.dark .pk-accent {
+  fill: #629eff;
+}
+
+.pk-accent-text {
+  fill: #184aff;
+}
+
+.dark .pk-accent-text {
+  fill: #629eff;
+}
+
+.pk-node {
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.pk-node:hover {
+  opacity: 0.72;
+}


### PR DESCRIPTION
Makes the passkey UI flow section graspable on first contact. The overview and benchmarking pages introduced ~25 terms across ~15 tables, with no diagrams, no reading order, and vocabulary spent on one page but defined on another.

**Preview the rendered result rather than reading this diff** — most of the file count is a mechanical rename.

## Structure
- Split the 28-flow catalogue out of `/overview` into a new `/flow-catalogue`. **The `/overview` URL and its "Passkey UI Best Practices" title are unchanged**, so existing links and SEO are unaffected. Overview is now a short visual entry point.
- Numbered sidebar to imply a reading order: 1. Start here, 2. Flow catalogue, 3. Benchmarking, 4. Passkey Intelligence.
- Catalogue grouped by lifecycle phase rather than platform, matching the map. Tables cut from 6 columns to 4; exact platform requirements moved to an availability matrix.
- Benchmarking restructured into 5 numbered steps.
- Passkey Intelligence reordered to lead with what it decides rather than what to log.

## Diagrams
Four inline SVGs, theme-aware via `currentColor` and clickable per node:
- Lifecycle map (Create / Log in / Manage, with Passkey Intelligence beneath), reused as navigation on both the overview and catalogue
- Benchmark rating ladder: scope → criterion → flow → pillar → result
- The four adoption pillars
- Passkey Intelligence decision map

## Terminology change
`Expected adoption impact` is renamed to **User reach** (column header: `Reach`). The old name shared both the word "adoption" and the High/Mid/Low scale with `Adoption potential`, which rates a whole implementation rather than a single flow. This accounts for 33 of the changed files, one line each in the acceptance-criteria snippets.

## Correction
The catalogue previously implied 31 flows. It holds **28** (16 web + 12 native), plus Passkey Intelligence.

## Checks
- `mintlify broken-links` passes
- All four pages render; all internal links and snippet imports resolve
- Verified in light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)